### PR TITLE
Resolve .vue extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ Elixir.ready(function () {
     resolve: {
       alias: {
         vue: 'vue/dist/vue.js'
-      }
+      },
+      extensions: ['.js', '.vue']
     },
     // use buble loader since it is the default in Elixir
     vue: {


### PR DESCRIPTION
By registering the `.vue` extension it's possible to `import` and require `modules` without writing the extension.
