### PR TITLE
Update vue-loader to version 10.0.0 to work with Vue 2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "file-loader": "^0.9.0",
     "sass-loader": "^4.0.0",
     "url-loader": "^0.5.7",
-    "vue-loader": "^9.3.2"
+    "vue-loader": "^10.0.0"
   }
 }


### PR DESCRIPTION
This bumps the vue-loader version to 10.0.0 to work with Vue2.1